### PR TITLE
Added request ether feature in solidity 

### DIFF
--- a/contracts/SocialIdentityLinker.sol
+++ b/contracts/SocialIdentityLinker.sol
@@ -9,7 +9,7 @@ contract SocialIdentityLinker is usingOraclize {
     uint256 public totalIdentities;
     mapping (uint256 => address) public facebookIdentity;
     mapping (bytes32 => address) requestMap;
-    mapping (address => mapping (address => uint)) requestEthMap;
+    mapping (address => mapping (address => uint)) public requestEthMap;
 
     modifier checkOwner() {require(owner == msg.sender); _ ;}
 
@@ -44,32 +44,16 @@ contract SocialIdentityLinker is usingOraclize {
         totalIdentities++;
     }
 
-    function requestEth(address _requester,
-                        address _requestee,
+    function requestEth(address _requestee,
                         uint _amount) public
     {
-        if (requestEthMap[_requester] == address(0x0)) {
-                requestEthMap[_requester] = _requestee;
-        }
-        if (requestEthMap[_requester][_requestee] == bytes4(0x0)) {
-                requestEthMap[_requester][_requestee] = 0;
-        }
-        requestEthMap[_requester][_requestee] += _amount;
+        requestEthMap[msg.sender][_requestee] = _amount;
     }
 
     function payEth(address _requester,
-                    address _requestee,
                     uint _amount) public
     {
-        //verify payable amount can't be greater than current balance
-        require(_amount <= requestEthMap[_requester][_requestee]);
-
-        requestEthMap[_requester][_requestee] -= _amount;
-
-        //delete mapping once balance reaches 0
-        if (requestEthMap[_requester][_requestee] == 0) {
-            delete requestEthMap[_requester][_requestee];
-        }
+        requestEthMap[_requester][msg.sender] -= _amount;
     }
 
     function setIdentity(


### PR DESCRIPTION
1. account0 request 123456789 wei to account1

truffle(develop)> app.requestEth(web3.eth.accounts[1], 123456789)

2. mapping correctly displayed the entry [account1 addr, owned amount] with input account0 addr and entry index

truffle(develop)> app.requestEthStruct(web3.eth.accounts[0],0)
[ '0xf17f52151ebef6c7334fad080c5704d77216b732',
  BigNumber { s: 1, e: 8, c: [ 123456789 ] } ]

3. account1 tried to pay account0 with a lesser amount, failed as expected
truffle(develop)> app.payEth(web3.eth.accounts[0], 0, {value: 9999999, from: web3.eth.accounts[1]})
Error: VM Exception while processing transaction: invalid opcode

4. account2 tried to pay account0, failed as expected
truffle(develop)> app.payEth(web3.eth.accounts[0], 0, {value: 123456789, from: web3.eth.accounts[2]})
Error: VM Exception while processing transaction: invalid opcode

5. account1 finally paid account0 with the whole amount

truffle(develop)> app.payEth(web3.eth.accounts[0], 0, {value: 123456789, from: web3.eth.accounts[1]})

truffle(develop)> app.requestEthStruct(web3.eth.accounts[0],0)
[ '0xf17f52151ebef6c7334fad080c5704d77216b732',
  BigNumber { s: 1, e: 0, c: [ 0 ] } ]

truffle(develop)> web3.eth.getBalance(web3.eth.accounts[0])
BigNumber { s: 1, e: 19, c: [ 983320, 56800129456789 ] }

truffle(develop)> web3.eth.getBalance(web3.eth.accounts[1])
BigNumber { s: 1, e: 19, c: [ 952861, 32499870543211 ] }
